### PR TITLE
Fix description of sheathed cock being overridden.

### DIFF
--- a/game.js
+++ b/game.js
@@ -1446,8 +1446,9 @@ let macro =
     if (this.maleParts) {
       if (this.hasSheath && this.arousal < 75) {
         line = "Your " + this.describeDick + " cock is hidden away in your bulging sheath, with two " + mass(macro.ballMass, unit, true) + ", " + length(macro.ballDiameter, unit, true) + "-wide balls hanging beneath.";
+      } else {
+        line = "Your " + this.describeDick + " cock hangs from your hips, with two " + mass(macro.ballMass, unit, true) + ", " + length(macro.ballDiameter, unit, true) + "-wide balls hanging beneath.";
       }
-      line = "Your " + this.describeDick + " cock hangs from your hips, with two " + mass(macro.ballMass, unit, true) + ", " + length(macro.ballDiameter, unit, true) + "-wide balls hanging beneath.";
       result.push(line);
       result.push(macro.balls.description);
     }


### PR DESCRIPTION
The sheathed description was never used, because it was always overridden by the non-sheathed description immediately afterwards.