### PR TITLE
Add permanent pane for macro description.

### DIFF
--- a/game.js
+++ b/game.js
@@ -4181,7 +4181,7 @@ function startGame(e) {
   enable_victim("ass-crush","Sat on");
   enable_victim("humped","Humped");
 
-  document.getElementById("log-area").style.display = 'inline';
+  document.getElementById("log-area").style.display = 'flex';
   document.getElementById("character-build-area").style.display = 'none';
   document.getElementById("action-panel").style.display = 'flex';
 
@@ -4544,7 +4544,14 @@ function startGame(e) {
   document.getElementById("actions-body").style.display = 'flex';
   document.getElementById("stat-container").style.display = 'flex';
 
+  window.requestAnimationFrame(lookAroundUpdate);
+
   window.scroll(0,0);
+}
+
+function lookAroundUpdate() {
+  document.getElementById('look-around-log').textContent = macro.description.join('\n');
+  window.requestAnimationFrame(lookAroundUpdate);
 }
 
 function actionTab(e) {

--- a/stroll.html
+++ b/stroll.html
@@ -188,6 +188,7 @@
       </div>
     </div>
     <div id="log-area">
+      <div id="look-around-log"></div>
       <div id="log">
         <div>Welcome to Stroll 0.7.1</div>
         <div><b>This game features 18+ content</b></div>

--- a/style.css
+++ b/style.css
@@ -62,21 +62,24 @@ body.dark div {
 }
 
 #log-area {
-  padding-left: 1em;
   flex: 5;
   display:none;
+  margin: 0.5em;
   flex-direction: column;
 }
 
 #look-around-log {
   flex: none;
-  padding-bottom: 1em;
+  margin-bottom: 1em;
+  padding: 0.5em;
+  background-color: #222;
   white-space: pre-wrap;
 }
 
 #log {
   flex: 0 1 auto;
   height: 600px;
+  padding: 1em;
   overflow: auto;
 }
 

--- a/style.css
+++ b/style.css
@@ -62,13 +62,25 @@ body.dark div {
 }
 
 #log-area {
+  padding-left: 1em;
   flex: 5;
   display:none;
+  flex-direction: column;
+}
+
+#look-around-log {
+  flex: none;
+  padding-bottom: 1em;
+  white-space: pre-wrap;
+}
+
+#log {
+  flex: 0 1 auto;
+  height: 600px;
+  overflow: auto;
 }
 
 body.light #log {
-  height: 900px;
-  overflow: auto;
   color: #000;
   background-color: #e7e7e7;
 }
@@ -78,8 +90,6 @@ body.light #log div {
 }
 
 body.dark #log {
-  height: 900px;
-  overflow: auto;
   color: #eee;
   background-color: #151515;
 }


### PR DESCRIPTION
We use textContent instead of innerText. It's much, much faster because it avoids reflowing the page. As a consequence, we need to change style to respect the linebreaks in the output.

Example on a small screen: ![image](https://user-images.githubusercontent.com/40283723/41501775-7d163a22-715f-11e8-8954-1fac85a728e5.png)
